### PR TITLE
I added edit authentication

### DIFF
--- a/general/templates/general/top.html
+++ b/general/templates/general/top.html
@@ -5,7 +5,10 @@
 <div class="welcome">
     <h1 class="title">Civic Seek</h1>
     <p class="subtitle">あなたの悩みを共有しましょう</p>
+    {% comment %} ユーザーがログイン状態にあるならば、課題登録ボタンを表示する {% endcomment %}
+    {% if user.is_authenticated %}
     <a class="btn btn-primary" href="{% url 'topics:topic_new' %}">課題を投稿する</a>
+    {% endif %}
 </div>
 
 


### PR DESCRIPTION
条件分岐をDjango templateで書こうと思ったが、is_authenticatedのテンプレートタグが機能しないため。
課題投稿ボタンをログインしているときのみ表示するようにした。

# 問題点
投稿ボタンのリダイレクト先をurlを直接指定することによって編集すると、DEBUG=Trueの場合はエラーメッセージが表示される。
そのため、ログインしていない人がデータベースにアクセスできないようにはなっている。
しかし、正常なリジェクト方法ではないため、どこかにセキュリティーホールが存在する可能性がある。